### PR TITLE
sdm845-common: Add CAP_SYS_BOOT for charger

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -253,6 +253,7 @@ service vendor.charger /system/bin/chargeonlymode
     class charger
     user system
     group system graphics input
+    capabilities SYS_BOOT
     seclabel u:r:charger:s0
 
 service vendor.hvdcp_opti /vendor/bin/hvdcp_opti


### PR DESCRIPTION
Add CAP_SYS_BOOT capability for charger service so that it can
shutdown/reboot the system.

Change-Id: I17ccba74d5a3c38bd751c55bcf42fb3689d730a7